### PR TITLE
vitest: clarify important default behavior difference for spies

### DIFF
--- a/blog/2025-11-zu-vitest-migrieren/README.md
+++ b/blog/2025-11-zu-vitest-migrieren/README.md
@@ -388,7 +388,7 @@ const onItem = jasmine.createSpy('onItem').and.returnValue(true);
 const onItem = vi.fn().mockName('onItem').mockReturnValue(true);
 ```
 
-#### Wichtiger Unterschied: Default-Verhalten von Spies
+#### Wichtiger Unterschied: Default-Verhalten von Spys
 
 Bei Jasmine gibt ein Spy standardmäßig `undefined` zurück, wenn keine spezifische Rückgabe konfiguriert wurde.
 In Vitest hingegen wird die **Original-Implementierung ausgeführt**, sofern du nicht explizit einen Mock-Wert setzt:
@@ -410,7 +410,7 @@ const result = service.rateUp(book);
 Dieser Unterschied ist besonders wichtig zu beachten, wenn du bestehende Jasmine-Tests zu Vitest migrierst.
 Falls du das ursprüngliche Verhalten von Jasmine benötigst (also `undefined` zurückgeben), musst du explizit `.mockReturnValue(undefined)` verwenden.
 
-#### Spies aufräumen
+#### Spys aufräumen
 
 Angular TestBed erstellt vor jedem Test eine neue Testumgebung.
 Dadurch werden auch Services neu instanziiert. Spys auf Services verschwinden also automatisch zwischen Tests.


### PR DESCRIPTION
This PR fixes an important inaccuracy in the Vitest migration guide regarding spy behavior.
The article previously stated that the spying concept works "almost identically" to Jasmine, but there's a **critical difference** in default behavior:

- **Jasmine**: `spyOn(service, 'method')` returns `undefined` by default (stubs the method)
- **Vitest**: `vi.spyOn(service, 'method')` executes the **original implementation** by default

This difference can lead to subtle bugs during migration if developers assume identical behavior. The new section makes this clear with code examples.