### PR TITLE
signal forms: align blog posts with submit-makeover changes

### DIFF
--- a/blog/2025-10-signal-forms-part1/README.md
+++ b/blog/2025-10-signal-forms-part1/README.md
@@ -353,7 +353,7 @@ export class RegistrationForm {
 ```
 
 
-### The elegant way: the `FormRoot` Directive
+### The Elegant Way: the `FormRoot` Directive
 
 All these manuel steps can be automated by using the `FormRoot` directive.
 It is the recommended way to trigger form submission.

--- a/blog/2025-10-signal-forms-part1/README.md
+++ b/blog/2025-10-signal-forms-part1/README.md
@@ -236,11 +236,11 @@ This is why we use the spread operator (`...`) to create a new array when adding
 export class RegistrationForm {
   // ...
   protected addEmail(): void {
-    this.registrationForm.email.value.update((items) => [...items, '']);
+    this.registrationForm.email().value.update((items) => [...items, '']);
   }
 
   protected removeEmail(removeIndex: number): void {
-    this.registrationForm.email.value.update((items) =>
+    this.registrationForm.email().value.update((items) =>
       items.filter((_, index) => index !== removeIndex)
     );
   }

--- a/blog/2025-10-signal-forms-part2/README.md
+++ b/blog/2025-10-signal-forms-part2/README.md
@@ -5,7 +5,7 @@ mail: mail@d-koppenhagen.de
 author2: Ferdinand Malcher
 mail2: mail@fmalcher.de
 published: 2025-10-15
-lastModified: 2026-01-08
+lastModified: 2026-02-21
 keywords:
   - Angular
   - Signals
@@ -91,7 +91,7 @@ import { /* ... */, applyEach, email } from '@angular/forms/signals';
 
 // ...
 applyEach(path.email, (emailPath) => {
-  email(emailPath, { message: 'E-Mail format is invalid.' });
+  email(emailPath, { message: 'E-mail format is invalid.' });
 });
 ```
 
@@ -103,7 +103,7 @@ The validation messages will be displayed in the UI since we included our generi
 <!-- ... -->
 <fieldset>
   <legend>
-    E-Mail Addresses
+    E-mail Addresses
     <button type="button" (click)="addEmail()">+</button>
   </legend>
   <div>
@@ -113,7 +113,7 @@ The validation messages will be displayed in the UI since we included our generi
         <input
           type="email"
           [formField]="emailField"
-          [aria-label]="'E-Mail ' + $index"
+          [aria-label]="'E-mail ' + $index"
           [aria-invalid]="ariaInvalidState(emailField)"
         />
         <button type="button" (click)="removeEmail($index)">-</button>
@@ -144,12 +144,12 @@ import { /* ... */, validate } from '@angular/forms/signals';
 
 export const registrationSchema = schema<RegisterFormData>((path) => {
   // ...
-  // E-Mail validation
+  // e-mail validation
   validate(path.email, (ctx) =>
     !ctx.value().some((e) => e)
       ? {
           kind: 'atLeastOneEmail',
-          message: 'At least one E-Mail address must be added.',
+          message: 'At least one e-mail address must be added.',
         }
       : undefined
   );
@@ -164,7 +164,7 @@ To display the error message, we add our `FormError` component below the `@for` 
 <!-- ... -->
 <fieldset>
   <legend>
-    E-Mail Addresses
+    E-mail Addresses
     <button type="button" (click)="addEmail()">+</button>
   </legend>
   <div>
@@ -487,39 +487,43 @@ import { /* ... */, WithFieldTree, ValidationError } from '@angular/forms/signal
 
 export class RegistrationForm {
   // ...
-  protected readonly registrationForm = form(this.registrationModel, registrationSchema, {
-    submission: {
-      action: async (form) => {
-        const errors: WithFieldTree<ValidationError>[] = [];
+  protected readonly registrationForm = form(
+    this.registrationModel,
+    registrationSchema,
+    {
+      submission: {
+        action: async (form) => {
+          const errors: WithFieldTree<ValidationError>[] = [];
 
-        try {
-          await this.#registrationService.registerUser(form().value);
-          console.log('Registration successful!');
-          this.resetForm();
-        } catch (e) {
-          // Add server-side errors
-          errors.push(
-            {
-              fieldTree: form, // form-level error
-              kind: 'serverError',
-              message: 'Registration failed. Please try again.',
-            }
-          );
+          try {
+            await this.#registrationService.registerUser(form().value);
+            console.log('Registration successful!');
+            this.resetForm();
+          } catch (e) {
+            // Add server-side errors
+            errors.push(
+              {
+                fieldTree: form, // form-level error
+                kind: 'serverError',
+                message: 'Registration failed. Please try again.',
+              }
+            );
 
-          // Or assign to specific field
-          errors.push(
-            {
-              fieldTree: form.username,
-              kind: 'serverValidation',
-              message: 'Username is not available.',
-            }
-          );
-        }
+            // Or assign to specific field
+            errors.push(
+              {
+                fieldTree: form.username,
+                kind: 'serverValidation',
+                message: 'Username is not available.',
+              }
+            );
+          }
 
-        return errors;
+          return errors;
+        },
       },
-    },
-  });
+    }
+  );
 }
 ```
 

--- a/blog/2025-10-signal-forms-part2/README.md
+++ b/blog/2025-10-signal-forms-part2/README.md
@@ -91,7 +91,7 @@ import { /* ... */, applyEach, email } from '@angular/forms/signals';
 
 // ...
 applyEach(path.email, (emailPath) => {
-  email(emailPath, { message: 'E-Mail format is invalid' });
+  email(emailPath, { message: 'E-Mail format is invalid.' });
 });
 ```
 
@@ -149,7 +149,7 @@ export const registrationSchema = schema<RegisterFormData>((path) => {
     !ctx.value().some((e) => e)
       ? {
           kind: 'atLeastOneEmail',
-          message: 'At least one E-Mail address must be added',
+          message: 'At least one E-Mail address must be added.',
         }
       : undefined
   );
@@ -241,7 +241,7 @@ export const registrationSchema = schema<RegisterFormData>((path) => {
       : {
           field: ctx.fieldTree.pw2, // assign the error to the second password field
           kind: 'confirmationPassword',
-          message: 'The entered password must match with the one specified in "Password" field',
+          message: 'The entered password must match with the one specified in "Password" field.',
         };
   });
 });
@@ -301,7 +301,7 @@ export const registrationSchema = schema<RegisterFormData>((path) => {
         !ctx.value().length
           ? {
               kind: 'noTopicSelected',
-              message: 'Select at least one newsletter topic',
+              message: 'Select at least one newsletter topic.',
             }
           : undefined
       );
@@ -349,7 +349,7 @@ export const registrationSchema = schema<RegisterFormData>((path) => {
   // Check username availability on the server
   validateAsync(path.username, {
     // Reactive parameters for the async operation
-    params: ({ value }) => value(),
+    params: (ctx) => ctx.value(),
 
     // Factory creating a resource for the async call
     factory: (params) => {
@@ -367,7 +367,7 @@ export const registrationSchema = schema<RegisterFormData>((path) => {
       return result
         ? {
             kind: 'userExists',
-            message: 'The username you entered was already taken',
+            message: 'The username you entered was already taken.',
           }
         : undefined;
     },
@@ -478,48 +478,48 @@ Instead, it marks the fields as *hidden*, which we can use in our template to co
 
 While client-side validation catches most errors before submission, server-side validation errors can still occur during form processing.
 Signal Forms provide an elegant way to handle these errors and display them to users with proper field-level feedback.
-When using the `submit()` function, we can return an array of validation errors from the submission callback to assign them to specific fields or to the form itself.
+From the `action` callback in the submission config, we can return an array of validation errors to assign them to specific fields or to the form itself.
 
-The type `ValidationErrorWithField` ensures that each error contains a reference to the field it belongs to.
+The type `WithFieldTree<ValidationError>` ensures that each error contains a reference to the field it belongs to.
 
 ```typescript
-import { /* ... */, ValidationErrorWithField } from '@angular/forms/signals';
+import { /* ... */, WithFieldTree, ValidationError } from '@angular/forms/signals';
 
 export class RegistrationForm {
   // ...
-  protected submitForm() {
-    submit(this.registrationForm, async (form) => {
-      const errors: ValidationErrorWithField[] = [];
+  protected readonly registrationForm = form(this.registrationModel, registrationSchema, {
+    submission: {
+      action: async (form) => {
+        const errors: WithFieldTree<ValidationError>[] = [];
 
-      try {
-        await this.#registrationService.registerUser(form().value);
-        console.log('Registration successful!');
-        this.reset();
-      } catch (e) {
-        // Add server-side errors
-        errors.push(
-          {
-            fieldTree: form, // form-level error
-            kind: 'serverError',
-            message: 'Registration failed. Please try again.',
-          }
-        );
+        try {
+          await this.#registrationService.registerUser(form().value);
+          console.log('Registration successful!');
+          this.resetForm();
+        } catch (e) {
+          // Add server-side errors
+          errors.push(
+            {
+              fieldTree: form, // form-level error
+              kind: 'serverError',
+              message: 'Registration failed. Please try again.',
+            }
+          );
 
-        // Or assign to specific field
-        errors.push(
-          {
-            fieldTree: form.username,
-            kind: 'serverValidation',
-            message: 'Username is not available.',
-          }
-        );
-      }
+          // Or assign to specific field
+          errors.push(
+            {
+              fieldTree: form.username,
+              kind: 'serverValidation',
+              message: 'Username is not available.',
+            }
+          );
+        }
 
-      return errors;
-    });
-
-    return false;
-  }
+        return errors;
+      },
+    },
+  });
 }
 ```
 

--- a/blog/2025-10-signal-forms-part3/README.md
+++ b/blog/2025-10-signal-forms-part3/README.md
@@ -211,7 +211,7 @@ Finally, we integrate the `IdentityForm` component in our main form template.
 To make things work, we pass the `identity` field tree of our main form to the child component via property binding.
 
 ```html
-<form (submit)="submit()">
+<form [formRoot]="registrationForm">
   <!-- ... -->
   <app-identity-form [identity]="registrationForm.identity" />
   <!-- ... -->

--- a/blog/2025-10-signal-forms-part3/README.md
+++ b/blog/2025-10-signal-forms-part3/README.md
@@ -5,7 +5,7 @@ mail: mail@d-koppenhagen.de
 author2: Ferdinand Malcher
 mail2: mail@fmalcher.de
 published: 2025-10-20
-lastModified: 2026-01-08
+lastModified: 2026-02-21
 keywords:
   - Angular
   - Signals

--- a/blog/2025-10-signal-forms-part3/README.md
+++ b/blog/2025-10-signal-forms-part3/README.md
@@ -92,11 +92,11 @@ export const identitySchema = schema<GenderIdentity>((path) => {
 
   required(path.salutation, {
     when: (ctx) => ctx.valueOf(path.gender) === 'diverse',
-    message: 'Please choose a salutation, when diverse gender selected',
+    message: 'Please choose a salutation, when diverse gender selected.',
   });
   required(path.pronoun, {
     when: (ctx) => ctx.valueOf(path.gender) === 'diverse',
-    message: 'Please choose a pronoun, when diverse gender selected',
+    message: 'Please choose a pronoun, when diverse gender selected.',
   });
 });
 ```
@@ -112,10 +112,10 @@ Finally, we import the `FormField` directive for binding the fields to our form 
 ```typescript
 @Component({
   // ...
-  imports: [Field, FormError]
+  imports: [FormField, FormError]
 })
 export class IdentityForm {
-  readonly identity = model.required<FieldTree<GenderIdentity>>();
+  readonly identity = input.required<FieldTree<GenderIdentity>>();
 
   protected updateSalutationAndPronoun() {
     this.identity().salutation().value.set('');
@@ -316,7 +316,7 @@ To show the current selection state, we can bind to the `checked` property: The 
 For changing the input we call a method `changeInput()` (we create it right after) with the (un)selected name and the native event.
 
 ```html
-<details class="dropdown" [ariaDisabled]="disabled()">
+<details class="dropdown" [aria-disabled]="disabled()">
   <summary>
     {{ label() }}
   </summary>
@@ -384,7 +384,7 @@ Our additional custom inputs `selectOptions` and `label` are set via property bi
   [selectOptions]="['Angular', 'React', 'Vue', 'Svelte']"
   label="Topics (multiple possible):"
 />
-<app-form-error [formField]="registrationForm.newsletterTopics" />
+<app-form-error [fieldRef]="registrationForm.newsletterTopics" />
 <!--- ... -->
 ```
 

--- a/blog/2025-12-signal-forms-part4/README.md
+++ b/blog/2025-12-signal-forms-part4/README.md
@@ -77,7 +77,7 @@ export const formSchema = schema<RegisterFormData>((path) => {
   metadata(path.username, FIELD_INFO, () => 'A username must consist of 3-12 characters.');
   // ...
   // Email metadata
-  metadata(path.email, FIELD_INFO, () => 'Please enter at least one valid e-mail address.');
+  metadata(path.email, FIELD_INFO, () => 'Please enter at least one valid e-mail address');
   // ...
   // Password metadata
   metadata(path.password, FIELD_INFO, () => 'Please enter a password with min 8 characters and a special character.');
@@ -228,16 +228,16 @@ import { FieldTree } from '@angular/forms/signals';
   },
 })
 export class FieldAriaAttributes<T> {
-  readonly field = input.required<FieldTree<T>>();
+  readonly formField = input.required<FieldTree<T>>();
   readonly fieldDescriptionId = input<string>();
 
   readonly ariaInvalid = computed(() => {
-    const state = this.field()();
+    const state = this.formField()();
     return state.touched() && !state.pending() ? state.errors().length > 0 : undefined;
   });
 
   readonly ariaBusy = computed(() => {
-    const state = this.field()();
+    const state = this.formField()();
     return state.pending();
   });
 

--- a/blog/2025-12-signal-forms-part4/README.md
+++ b/blog/2025-12-signal-forms-part4/README.md
@@ -5,7 +5,7 @@ mail: mail@d-koppenhagen.de
 author2: Ferdinand Malcher
 mail2: mail@fmalcher.de
 published: 2025-12-08
-lastModified: 2026-01-08
+lastModified: 2026-02-21
 keywords:
   - Angular
   - Signals

--- a/blog/2025-12-signal-forms-part4/README.md
+++ b/blog/2025-12-signal-forms-part4/README.md
@@ -72,8 +72,8 @@ import { FIELD_INFO } from './form-props';
 // ...
 export const formSchema = schema<RegisterFormData>((path) => {
   // Username validation and metadata
-  required(path.username, { message: 'Username is required' });
-  minLength(path.username, 3, { message: 'A username must be at least 3 characters long' });
+  required(path.username, { message: 'Username is required.' });
+  minLength(path.username, 3, { message: 'A username must be at least 3 characters long.' });
   metadata(path.username, FIELD_INFO, () => 'A username must consist of 3-12 characters.');
   // ...
   // Email metadata


### PR DESCRIPTION
Aligns all four Signal Forms blog posts with the `submit-makeover` branch changes: https://github.com/angular-buch/signal-forms-registration/pull/14

- Use `FormRoot` directive and `submission: { action }` config as primary submission pattern
- Add manual `submit()` function as documented alternative (Part 1)
- Rename `ValidationErrorWithField` → `WithFieldTree<ValidationError>` (Part 2)
- Add trailing periods to all validation messages
- Update `validateAsync` params: `({ value }) => value()` → `(ctx) => ctx.value()`
- Code snippets build up incrementally (no premature `FormRoot` or schema references)