### PR TITLE
docs(signal-forms-part4): update accessibility guide with focus handling

### DIFF
--- a/blog/2025-12-signal-forms-part4/README.md
+++ b/blog/2025-12-signal-forms-part4/README.md
@@ -320,7 +320,7 @@ We can leverage the `onInvalid` callback in the submission configuration for thi
 The `onInvalid` callback is triggered when the user attempts to submit the form while it still contains validation errors.
 We use the `errorSummary()` method to get a list of all current errors across the whole form.
 Each error entry provides access to the associated `fieldTree`.
-Invoking it as a signal with `fieldTree()` returns the corresponding `FieldState`, which exposes the `focusBoundControl()` method.
+Invoking it as a function returns the corresponding `FieldState`, which exposes the `focusBoundControl()` method.
 By calling `focusBoundControl()` on the first error's `FieldState`, the browser focus is moved directly to the first invalid input element in DOM order.
 
 At the same time, all invalid fields are automatically marked as touched, so their error messages become visible immediately.


### PR DESCRIPTION
- Update lastModified date to 2026-02-23
- Add "Focus Handling" keyword to article metadata
- Rename directive selector from `[formField]` to `[formFieldAria]` for clarity and independence
- Rename input property from `formField` to `formFieldAria` to match selector
- Update directive documentation to explain explicit selector approach
- Clarify that directive uses its own binding alongside `FormField` directive
- Fix import reference from `Field` to `FormField` in component example
- Add new section "Handling Invalid Form Submission" with focus management implementation
- Include example of `onInvalid` callback using `focusBoundControl()` method
- Add outlook note about Directive Composition API as alternative approach
- Add accessibility tip about native HTML `autocomplete` attribute
- Remove duplicate line about removing `ariaInvalidState()` method