### PR TITLE
feat: introduce sortKey for material chapter order

### DIFF
--- a/material/content-projection/README.md
+++ b/material/content-projection/README.md
@@ -2,6 +2,7 @@
 title: "Content Projection: Inhalte an Komponenten übergeben"
 published: 2026-05-15
 lastModified: 2026-05-15
+sortKey: 3
 ---
 
 Wenn wir eine Komponente in unser Template einbinden, notieren wir sie üblicherweise ohne weiteren Inhalt zwischen dem öffnenden und schließenden Tag.

--- a/material/directives/README.md
+++ b/material/directives/README.md
@@ -2,6 +2,7 @@
 title: 'Direktiven: Logik für DOM-Elemente'
 published: 2026-04-25
 lastModified: 2026-04-25
+sortKey: 2
 ---
 
 In diesem Artikel geht es um *Direktiven* in Angular.

--- a/material/i18n/README.md
+++ b/material/i18n/README.md
@@ -2,6 +2,7 @@
 title: 'Lokalisierung (l10n) und Internationalisierung (i18n) mit Angular'
 published: 2026-03-02
 lastModified: 2026-03-03
+sortKey: 8
 ---
 
 In diesem Artikel geht es darum, wie wir unsere Angular-Anwendung für verschiedene Sprachräume lokalisieren und in mehreren Sprachen ausliefern können.

--- a/material/interceptors/README.md
+++ b/material/interceptors/README.md
@@ -2,6 +2,7 @@
 title: 'Interceptors: HTTP-Requests erfassen und transformieren'
 published: 2026-03-06
 lastModified: 2026-03-06
+sortKey: 4
 ---
 
 In diesem Artikel geht es um *Interceptors* in Angular. Damit lassen sich HTTP-Requests und -Responses zentral erfassen und transformieren.

--- a/material/reactive-forms/README.md
+++ b/material/reactive-forms/README.md
@@ -2,6 +2,7 @@
 title: 'Formulare mit Reactive Forms'
 published: 2026-03-26
 lastModified: 2026-03-26
+sortKey: 5
 ---
 
 Formulare gehören zu den zentralen Bausteinen jeder Webanwendung.

--- a/material/ssr/README.md
+++ b/material/ssr/README.md
@@ -2,6 +2,7 @@
 title: 'Server-Side Rendering (SSR) mit Angular'
 published: 2026-02-23
 lastModified: 2026-03-02
+sortKey: 7
 ---
 
 Single-Page-Anwendungen mit Angular bieten grundsätzlich eine gute Performance:

--- a/material/template-forms/README.md
+++ b/material/template-forms/README.md
@@ -2,6 +2,7 @@
 title: 'Formulare mit Template-Driven Forms'
 published: 2026-04-08
 lastModified: 2026-04-08
+sortKey: 6
 ---
 
 Formulare gehören zu den zentralen Bausteinen jeder Webanwendung.

--- a/material/typescript/README.md
+++ b/material/typescript/README.md
@@ -2,6 +2,7 @@
 title: 'Einführung in TypeScript'
 published: 2026-05-14
 lastModified: 2026-05-14
+sortKey: 1
 ---
 
 Für die Entwicklung mit Angular verwenden wir die Programmiersprache **TypeScript**.


### PR DESCRIPTION
Bumps the build submodule to the new main (sortKey support, angular-schule/website-articles-build#3) and assigns sortKey values to the 8 visible online chapters in the order they should appear:

1. TypeScript (foundation)
2. Direktiven
3. Content Projection
4. Interceptors
5. Reactive Forms
6. Template-Driven Forms
7. SSR
8. i18n

Errata and `signal-forms` (hidden) keep no sortKey.