### PR TITLE
blog(angular22): link to English translation

### DIFF
--- a/blog/2026-06-angular22/README.md
+++ b/blog/2026-06-angular22/README.md
@@ -35,7 +35,7 @@ Diese und einige weitere Neuerungen stellen wir in diesem Blogpost vor.
 Im [Angular-Blog](https://blog.angular.dev/announcing-angular-v22-c52bb83a4664) findest du die offiziellen Informationen zum neuen Release.
 Um ein bestehendes Projekt auf Angular 22 zu migrieren, kannst du den Befehl `ng update` verwenden, siehe [Angular Update Guide](https://angular.dev/update-guide).
 
-<!-- > 🇬🇧 This article is available in English language here: [Angular 22 is here!](https://angular.schule/blog/TODO) -->
+> 🇬🇧 This article is available in English language here: [Angular 22 is here!](https://angular.schule/blog/2026-06-angular22)
 
 ## Versionen von TypeScript und Node.js
 

--- a/blog/2026-06-angular22/README.md
+++ b/blog/2026-06-angular22/README.md
@@ -37,6 +37,10 @@ Um ein bestehendes Projekt auf Angular 22 zu migrieren, kannst du den Befehl `ng
 
 > 🇬🇧 This article is available in English language here: [Angular 22 is here!](https://angular.schule/blog/2026-06-angular22)
 
+## Inhalt
+
+[[toc]]
+
 ## Versionen von TypeScript und Node.js
 
 Die folgenden Versionen von TypeScript und Node.js sind für Angular 22 notwendig:


### PR DESCRIPTION
Activates the 🇬🇧 cross-link banner in the German Angular 22 article, pointing to the new English translation at `angular.schule/blog/2026-06-angular22`.

Companion PR: angular-schule/website-articles (English translation).