### PR TITLE
angular21: Verweis auf unveröffentlichten Vibe-Coding-Artikel entfernt

### DIFF
--- a/blog/2025-11-angular21/README.md
+++ b/blog/2025-11-angular21/README.md
@@ -249,8 +249,6 @@ Der MCP-Server bietet aktuell sieben Tools an:
 6. Die Dokumentation durchsuchen (`search_documentation`).
 7. Code-Migrationen mit Schematics durchführen (`modernize`, **experimentell**).
 
-<!-- Mehr Details zu `AGENTS.md`, MCP und praktischen Erfahrungen findest du in unserem ausführlichen Artikel über [Vibe-Coding mit Angular](/blog/2025-11-ai-mcp-vibe-coding). -->
-
 
 ## Migrationsskripte
 


### PR DESCRIPTION
Der auskommentierte Link zeigt auf `/blog/2025-11-ai-mcp-vibe-coding` — der Artikel wurde nie veröffentlicht, sein Inhalt ist im Claude-Code-Artikel aufgegangen. Der Draft liegt nur noch auf dem Branch `ng21mcp`, der damit gelöscht werden kann.