### PR TITLE
feat: enable standard.site publishing (blog + material)

### DIFF
--- a/.github/workflows/build-article-data.yml
+++ b/.github/workflows/build-article-data.yml
@@ -26,6 +26,15 @@ jobs:
           node-version: 22.x
 
       - name: Build
+        env:
+          # standard.site publisher (see build/STANDARD-SITE.md).
+          # The step is a no-op unless BSKY_APP_PASSWORD is set.
+          BSKY_APP_PASSWORD: ${{ secrets.BSKY_APP_PASSWORD }}
+          BSKY_HANDLE: angular-buch.com
+          STANDARD_SITE_URL: https://angular-buch.com
+          STANDARD_SITE_NAME: Angular-Buch
+          STANDARD_SITE_DESCRIPTION: Der Blog zum Angular-Buch – das deutschsprachige Praxisbuch zu Angular.
+          STANDARD_SITE_EXPECTED_DID: did:plc:emeppmrqgb5rixbjcjihzd35
         run: |
           cd build
           npm install


### PR DESCRIPTION
Enables the site's **standard.site** (AT Protocol) publishing by adopting the publisher from `website-articles-build` and wiring angular-buch.com's config into CI. Publishes both **blog posts** and **material chapters** as `site.standard.document` records.

## Changes
- **Submodule bump** `build`: `0bb1055` → `775a3d1` — brings in the standard.site publisher with blog + material support (angular-schule/website-articles-build#6). (This also picks up other build improvements accumulated since the old pin, e.g. WebP image optimization.)
- **`build-article-data.yml`**: adds the publication `env` to the build step (handle `angular-buch.com`, URL, name, description, DID) plus the `BSKY_APP_PASSWORD` secret.

## Before this goes live
Add the repo secret **`BSKY_APP_PASSWORD`** (Settings → Secrets and variables → Actions) — a Bluesky *app password* for the `angular-buch.com` account. Until it's set, the publish step is a **no-op**, so merging this alone changes nothing.

## What happens once the secret exists
On each article-data build, the publisher upserts one `site.standard.publication` record + one `site.standard.document` per non-hidden blog post and material chapter (rkey = slug) to the `angular-buch.com` PDS, and prunes stale ones. The existing `trigger-website-rebuild` chain then redeploys the website, whose verification artifacts are added in angular-schule/angular-buch-website#64.

Dry run against current content: **1 publication + 53 blog + 10 material = 63 documents**.

Details & config keys: `build/STANDARD-SITE.md`.