### PR TITLE
feat: set standard.site publication icon

### DIFF
--- a/.github/workflows/build-article-data.yml
+++ b/.github/workflows/build-article-data.yml
@@ -35,6 +35,7 @@ jobs:
           STANDARD_SITE_NAME: Angular-Buch
           STANDARD_SITE_DESCRIPTION: Der Blog zum Angular-Buch – das deutschsprachige Praxisbuch zu Angular.
           STANDARD_SITE_EXPECTED_DID: did:plc:emeppmrqgb5rixbjcjihzd35
+          STANDARD_SITE_ICON: https://angular-buch.com/standard-site-icon.png
         run: |
           cd build
           npm install


### PR DESCRIPTION
Adds a **profile image** to the standard.site publication record.

## Changes
- **Submodule bump** `build`: `775a3d1` → `9993e89` — adds publication `icon` support (angular-schule/website-articles-build#7).
- **`build-article-data.yml`**: `STANDARD_SITE_ICON=https://angular-buch.com/standard-site-icon.png` (deployed via angular-schule/angular-buch-website#65).

On the next article-data build the publisher uploads that image as a blob and sets it as the `site.standard.publication` `icon`. Icon fetch is non-fatal.